### PR TITLE
WIP: handle multi-recipient thread titles

### DIFF
--- a/src/app/components/Recipients.jsx
+++ b/src/app/components/Recipients.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+const recipients = ({ recipients, username }) => {
+  let joined = "";
+  if ((typeof recipients) === "object") {
+    // probably a private message (list of recipients)
+    const names = recipients.map(r => r.full_name);
+    if ((recipients.length === 1) && (recipients[0].email === username)) {
+      joined = "You"
+    } else {
+      const index = recipients.map(r => r.email).indexOf(username);
+      names.splice(index, 1);
+      if (names.length === 1) {
+        joined = names[0];
+      } else {
+        const last = names[names.length -1];
+        const others = names.slice(0, -1).join(", ");
+        joined = `${others} and ${last}`;
+      }
+    }
+  } else {
+    joined = recipients;
+  }
+  return <div>{joined}</div>;
+}
+
+export default connect(({ config }) => {
+  return { username: config.username };
+})(recipients);

--- a/src/app/components/ThreadSubject.jsx
+++ b/src/app/components/ThreadSubject.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { wrapper, dot } from '../styles/threadSubject';
+
+export default ({ subject }) => {
+  if (subject) {
+    return <div style={wrapper}>
+      <div style={dot}>&middot;</div>
+      <div>{subject}</div>
+    </div>;
+  }
+  return null;
+}

--- a/src/app/components/ThreadTitle.jsx
+++ b/src/app/components/ThreadTitle.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import threadTitle from '../styles/threadTitle';
-import dot from '../styles/dot';
+import style from '../styles/threadTitle';
+import Recipients from './Recipients';
+import ThreadSubject from './ThreadSubject';
 
-export default ({ display_recipient, subject }) => <div style={threadTitle}>
-  <div>{display_recipient}</div>
-  <div style={dot}>&middot;</div>
-  <div>{subject}</div>
-</div>;
+export default ({ display_recipient, subject }) => {
+  return <div style={style}>
+    <Recipients recipients={display_recipient} />
+    <ThreadSubject subject={subject} />
+  </div>;
+}

--- a/src/app/styles/dot.js
+++ b/src/app/styles/dot.js
@@ -1,4 +1,0 @@
-export default {
-  marginLeft: 4,
-  marginRight: 4,
-};

--- a/src/app/styles/threadSubject.js
+++ b/src/app/styles/threadSubject.js
@@ -1,0 +1,8 @@
+export const dot = {
+  marginLeft: 4,
+  marginRight: 4,
+};
+
+export const wrapper = {
+  display: 'flex',
+};


### PR DESCRIPTION
The idea is to handle multiple recipients (such as PMs) by joining the recipients names with commas (and possibly adding an and at the end). 
Ideally the current user's name should be removed from this list (possibly replaced with "you")
This is to fix #17 