### PR TITLE
upgrade momentjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "cookie-parser": "1.4.3",
     "emoji-js": "3.4.0",
     "express": "4.14.0",
-    "moment": "2.18.1",
+    "moment": "2.19.3",
     "parcel-bundler": "1.4.1",
     "react": "16.2.0",
     "react-cookie": "0.4.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3144,9 +3144,9 @@ mixin-deep@^1.2.0:
   dependencies:
     minimist "0.0.8"
 
-moment@2.18.1:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
+moment@2.19.3:
+  version "2.19.3"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.3.tgz#bdb99d270d6d7fda78cc0fbace855e27fe7da69f"
 
 ms@0.7.1:
   version "0.7.1"


### PR DESCRIPTION
[CVE-2017-18214](https://nvd.nist.gov/vuln/detail/CVE-2017-18214)
Moderate severity
The moment module before 2.19.3 for Node.js is prone to a regular expression denial of service via a crafted date string, a different vulnerability than CVE-2016-4055.