### PR TITLE
Static site  - deploy to github pages from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,12 @@ node_js:
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.5.1
   - export PATH="$HOME/.yarn/bin:$PATH"
+script:
+  - npm run build-gh-pages
+deploy:
+  provider: pages
+  skip_cleanup: true
+  local_dir: dist
+  github_token: $github_token
+  on:
+    branch: master

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "parcel src/index.html",
     "build-client": "parcel build src/index.html -d dist/client --public-url /dist",
     "build-server": "babel src -d dist/server --ignore __tests__ --copy-files",
+    "build-gh-pages": "parcel build src/index.html --public-url ./",
     "build": "npm run build-client && npm run build-server",
     "postinstall": "npm run build"
   },


### PR DESCRIPTION
This PR creates a new build script in package.json:
build-gh-pages is similar to build-client except it doesn't
use a dist folder

travis.yml deploys to gh-pages branch from master
(using the build-gh-pages script)

Fixes #31 