### PR TITLE
Support Emojis in Thread Titles

### DIFF
--- a/src/app/components/ThreadTitle.jsx
+++ b/src/app/components/ThreadTitle.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { replaceColons } from '../emoji';
 import style from '../styles/threadTitle';
 import Recipients from './Recipients';
 import ThreadSubject from './ThreadSubject';
@@ -6,6 +7,6 @@ import ThreadSubject from './ThreadSubject';
 export default ({ display_recipient, subject }) => {
   return <div style={style}>
     <Recipients recipients={display_recipient} />
-    <ThreadSubject subject={subject} />
+    <ThreadSubject subject={replaceColons(subject)} />
   </div>;
 }


### PR DESCRIPTION
Some thread titles have emoji names in them, for example `:tada:`. This pull request replaces the emoji name with the actual emoji.