### PR TITLE
ThreadTitle: prevent wrapping of long thread titles

### DIFF
--- a/src/app/styles/threadTitle.js
+++ b/src/app/styles/threadTitle.js
@@ -2,4 +2,6 @@ export default {
   display: 'flex',
   flexDirection: 'row',
   fontWeight: 500,
+  overflow: 'scroll',
+  whiteSpace: 'nowrap',
 };


### PR DESCRIPTION
The thread title is now scrollable horizontally if there is an overflow.
This fixes #30