### PR TITLE
Remove reaction outline

### DIFF
--- a/src/app/styles/reaction.js
+++ b/src/app/styles/reaction.js
@@ -11,6 +11,7 @@ export const style = {
   cursor: 'pointer',
   fontSize: 'inherit',
   transition: 'background-color 200ms linear',
+  outline: 0,
 };
 
 export const hover = {...style, backgroundColor: 'rgba(0,162,255,0.8)' };


### PR DESCRIPTION
When clicking a reaction, a square blue outline appears. This doesn't fit well with the circular reaction button shape. This PR removes that outline.